### PR TITLE
Add workout logging linked to users

### DIFF
--- a/ProjectSourceCode/SRC/Views/Pages/calendar.hbs
+++ b/ProjectSourceCode/SRC/Views/Pages/calendar.hbs
@@ -31,17 +31,14 @@
                     </tr>
                   </thead>
                   <tbody id="workout_logs">
-                    <!-- Workout logs will be dynamically inserted here -->
-                      <tr>
-                        <td>{{date}}</td>
-                        <td>{{workoutname}}</td>
-                        <td>{{workoutduration}} minutes</td>
-                        <td>{{exercise_categories}}</td>
-                        <td>
-                          <button class="btn btn-danger btn-sm" onclick="deleteWorkout({{id}})">Delete</button>
-                          <button class="btn btn-secondary btn-sm" onclick="editWorkout({{id}})">Edit</button>
-                        </td>
-                      </tr>
+                    {{#each logs}}
+                    <tr>
+                      <td>{{date}}</td>
+                      <td>{{workoutname}}</td>
+                      <td>{{workoutduration}} minutes</td>
+                      <td>{{exercise_categories}}</td>
+                    </tr>
+                    {{/each}}
                   </tbody>
                 </table>
               </div>
@@ -60,15 +57,14 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
-            <form id="event_form">
+            <form id="event_form" method="POST" action="/log-workout">
               <div class="mb-3">
                 <label for="event_name" class="form-label">Workout Name</label>
-                <input type="text" class="form-control" id="event_name" required>
+                <input type="text" class="form-control" name="workoutname" id="event_name" required>
               </div>
               <div class="mb-3">
                 <label for="event_category" class="form-label">Exercise Categories</label>
-                <select class="form-select" id="event_category" required>
-                  <option value="">Select category</option>
+                <select class="form-select" name="category" id="event_category" required>
                   <option value="Cardio">Cardio</option>
                   <option value="Weightlifting">Weightlifting</option>
                   <option value="Calisthenics">Calisthenics</option>
@@ -76,22 +72,33 @@
               </div>
               <div class="mb-3">
                 <label for="event_date" class="form-label">Date</label>
-                <input type="date" class="form-control" id="event_date" required>
-              </div>
-
+                <input type="date" class="form-control" name="date" id="event_date" required>
               </div>
               <div class="mb-3">
-                <label for="event_time" class="form-label">Time</label>
-                <input type="time" class="form-control" id="event_time" required>
+                <label for="event_duration" class="form-label">Duration (minutes)</label>
+                <input type="number" class="form-control" name="workoutduration" id="event_duration" required>
               </div>
-                <div class="mb-3">
-                    <label for="event_duration" class="form-label">Duration (minutes)</label>
-                    <input type="number" class="form-control" id="event_duration" required>     
+              <div class="mb-3">
+                <label for="event_sets" class="form-label">Sets</label>
+                <input type="number" class="form-control" name="sets" id="event_sets">
+              </div>
+              <div class="mb-3">
+                <label for="event_reps" class="form-label">Reps</label>
+                <input type="number" class="form-control" name="reps" id="event_reps">
+              </div>
+              <div class="mb-3">
+                <label for="event_weight" class="form-label">Weight (lbs)</label>
+                <input type="number" step="0.1" class="form-control" name="weight" id="event_weight">
+              </div>
+              <div class="mb-3">
+                <label for="event_distance" class="form-label">Distance (miles)</label>
+                <input type="number" step="0.01" class="form-control" name="distance" id="event_distance">
+              </div>
             </form>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            <button type="button" class="btn btn-primary" onclick="saveEvent()">Save Workout</button>
+            <button type="submit" form="event_form" class="btn btn-primary">Save Workout</button>
           </div>
         </div>
       </div>

--- a/ProjectSourceCode/SRC/Views/Pages/home.hbs
+++ b/ProjectSourceCode/SRC/Views/Pages/home.hbs
@@ -11,3 +11,61 @@
         <li><a href="/logout">Logout</a></li>
     </ul>
 </nav>
+
+<button class="btn btn-primary mt-3" data-bs-toggle="modal" data-bs-target="#log_modal">Log a Workout</button>
+
+<!-- Log Workout Modal -->
+<div class="modal fade" id="log_modal" tabindex="-1" aria-labelledby="log_label" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="log_label">Log a Workout</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form method="POST" action="/log-workout">
+        <div class="modal-body">
+          <div class="mb-3">
+            <label for="workoutname" class="form-label">Workout Name</label>
+            <input type="text" class="form-control" name="workoutname" id="workoutname" required>
+          </div>
+          <div class="mb-3">
+            <label for="category" class="form-label">Category</label>
+            <select class="form-select" name="category" id="category" required>
+              <option value="Cardio">Cardio</option>
+              <option value="Weightlifting">Weightlifting</option>
+              <option value="Calisthenics">Calisthenics</option>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label for="date" class="form-label">Date</label>
+            <input type="date" class="form-control" name="date" id="date" required>
+          </div>
+          <div class="mb-3">
+            <label for="duration" class="form-label">Duration (minutes)</label>
+            <input type="number" class="form-control" name="workoutduration" id="duration" required>
+          </div>
+          <div class="mb-3">
+            <label for="sets" class="form-label">Sets</label>
+            <input type="number" class="form-control" name="sets" id="sets">
+          </div>
+          <div class="mb-3">
+            <label for="reps" class="form-label">Reps</label>
+            <input type="number" class="form-control" name="reps" id="reps">
+          </div>
+          <div class="mb-3">
+            <label for="weight" class="form-label">Weight (lbs)</label>
+            <input type="number" step="0.1" class="form-control" name="weight" id="weight">
+          </div>
+          <div class="mb-3">
+            <label for="distance" class="form-label">Distance (miles)</label>
+            <input type="number" step="0.01" class="form-control" name="distance" id="distance">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          <button type="submit" class="btn btn-primary">Save Workout</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/ProjectSourceCode/SRC/Views/Pages/milestones.hbs
+++ b/ProjectSourceCode/SRC/Views/Pages/milestones.hbs
@@ -3,18 +3,14 @@
   <p class="text-center">Track your progress across different categories.</p>
   <h5>Calisthenics</h5>
   <div class="progress mb-3">
-    <div class="progress-bar" role="progressbar" style="width:40%">40%</div>
+    <div class="progress-bar" role="progressbar" style="width:{{calisthenics}}%">{{calisthenics}}%</div>
   </div>
   <h5>Cardio</h5>
   <div class="progress mb-3">
-    <div class="progress-bar bg-success" role="progressbar" style="width:60%">60%</div>
+    <div class="progress-bar bg-success" role="progressbar" style="width:{{cardio}}%">{{cardio}}%</div>
   </div>
   <h5>Weightlifting</h5>
   <div class="progress mb-3">
-    <div class="progress-bar bg-info" role="progressbar" style="width:25%">25%</div>
-  </div>
-  <h5>Fitness Metrics</h5>
-  <div class="progress mb-3">
-    <div class="progress-bar bg-warning" role="progressbar" style="width:50%">50%</div>
+    <div class="progress-bar bg-info" role="progressbar" style="width:{{weightlifting}}%">{{weightlifting}}%</div>
   </div>
 </div>

--- a/ProjectSourceCode/SRC/init_data/create.sql
+++ b/ProjectSourceCode/SRC/init_data/create.sql
@@ -10,10 +10,15 @@ CREATE TABLE IF NOT EXISTS users (
 -- Table for storing workout logs
 CREATE TABLE IF NOT EXISTS workoutlogs (
   id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
   workoutname VARCHAR(100) NOT NULL,
-  date DATE NOT NULL, 
+  date DATE NOT NULL,
   workoutduration SMALLINT NOT NULL,
-  exercise_categories VARCHAR(100) NOT NULL
+  exercise_categories VARCHAR(100) NOT NULL,
+  sets SMALLINT,
+  reps SMALLINT,
+  weight FLOAT,
+  distance FLOAT
 );
 
 CREATE TABLE IF NOT EXISTS cardiologs (

--- a/ProjectSourceCode/SRC/init_data/insert.sql
+++ b/ProjectSourceCode/SRC/init_data/insert.sql
@@ -69,3 +69,29 @@ VALUES
     'fake@gmail.com',
     '1234'
   );
+
+-- Sample workout log linked to user
+INSERT INTO workoutlogs
+  (
+    user_id,
+    workoutname,
+    date,
+    workoutduration,
+    exercise_categories,
+    sets,
+    reps,
+    weight,
+    distance
+  )
+VALUES
+  (
+    1,
+    'Sample Workout',
+    '2023-10-03',
+    30,
+    'Cardio',
+    NULL,
+    NULL,
+    NULL,
+    3.0
+  );

--- a/README.md
+++ b/README.md
@@ -6,15 +6,17 @@ You can access all head pages from all other pages
 
 From the home page, users are prompted to access the **Signup**, **Registration**, **Exercises** **Calendar**, **Milestones**, and **Movement Library** pages.
 
+The home page also allows users to quickly log a workout using a simple modal form. Logged workouts are stored in the database and tied to the current user so they can be viewed later on the calendar and milestones pages.
+
 From **Signup**, you are prompted to access **Registration** and vice versa.
 "Already have an account? -> signup" and "Need to sign up? -> registration"
 
 
-In **Exercises**, the user is prompted to create or log workouts. 
-In **Milestones**, the user can view their progress across various trees: calisthenics, cardio, weightlifting, and fitness metrics. 
-These trees should be animated graphs, duolingo style (but simpler) with progression of various achievements (calisthenics skills, cardio stats ,etc). These pages should pull data from the workout logs table in our sql
+In **Exercises**, the user is prompted to create or log workouts.
+In **Milestones**, the user can view their progress across various trees: calisthenics, cardio, weightlifting, and fitness metrics.
+These trees should be animated graphs, duolingo style (but simpler) with progression of various achievements (calisthenics skills, cardio stats ,etc). These pages pull data from each user's workout logs in the database.
 In **Movement Library**, there is a searchable library of exercises powered by [ExerciseDB](https://www.exercisedb.dev/). Use the search bar to find movements by name, muscle group or equipment and view detailed instructions.
-In **Calendar**, there is a calendar populated with user workout data, notes, anything we decide is useful (all pulled from db). 
+In **Calendar**, there is a calendar populated with user workout data pulled from the database.
 Under **Signup/Registration**, the user is prompted to log in to their account or create a new one.
 
 ## Running


### PR DESCRIPTION
## Summary
- extend `workoutlogs` table schema with user and exercise fields
- seed new workout log in insert script
- implement workout logging routes and link weightlifting page
- compute user progress for milestones page
- show workout data on calendar and allow logging via modal
- allow quick workout logging from home page
- document new workflow in README

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_688270b982d4832f968e1f955d58f386