### PR TITLE
Add movement name to logs

### DIFF
--- a/ProjectSourceCode/SRC/Views/Pages/home.hbs
+++ b/ProjectSourceCode/SRC/Views/Pages/home.hbs
@@ -10,7 +10,7 @@
       <strong>{{date}}</strong>
       <ul class="list-unstyled mb-0">
         {{#each logs}}
-        <li>{{workoutname}}</li>
+        <li>{{workoutname}} - {{exercise_name}} ({{exercise_categories}})</li>
         {{/each}}
       </ul>
     </div>

--- a/ProjectSourceCode/SRC/index.js
+++ b/ProjectSourceCode/SRC/index.js
@@ -67,7 +67,7 @@ const auth = (req, res, next) => {
 app.get('/', auth, async (req, res) => {
   try {
     const logs = await db.any(
-      `SELECT workoutname, date, workoutduration, exercise_categories,
+      `SELECT workoutname, exercise_name, date, workoutduration, exercise_categories,
               sets, reps, weight, distance
        FROM workoutlogs
        WHERE user_id = $1 AND date >= CURRENT_DATE - INTERVAL '6 days'
@@ -295,6 +295,7 @@ app.get('/api/exercises', auth, async (req, res) => {
 app.post('/log-workout', auth, async (req, res) => {
   const {
     workoutname,
+    exercisename,
     date,
     workoutduration,
     category,
@@ -322,12 +323,13 @@ app.post('/log-workout', auth, async (req, res) => {
 
     await db.none(
       `INSERT INTO workoutlogs
-       (user_id, calendar_day_id, workoutname, date, workoutduration, exercise_categories, sets, reps, weight, distance)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+       (user_id, calendar_day_id, workoutname, exercise_name, date, workoutduration, exercise_categories, sets, reps, weight, distance)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
       [
         req.session.user.id,
         dayId,
         workoutname,
+        exercisename || null,
         date,
         workoutduration || null,
         category,

--- a/ProjectSourceCode/SRC/init_data/create.sql
+++ b/ProjectSourceCode/SRC/init_data/create.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS workoutlogs (
   user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
   calendar_day_id INTEGER REFERENCES calendar_days(id) ON DELETE CASCADE,
   workoutname VARCHAR(100) NOT NULL,
+  exercise_name VARCHAR(100),
   date DATE NOT NULL,
   workoutduration SMALLINT,  -- nullable
   exercise_categories VARCHAR(100) NOT NULL,
@@ -77,5 +78,16 @@ BEGIN
           AND is_nullable = 'NO'
   ) THEN
     ALTER TABLE weightliftinglogs ALTER COLUMN workoutduration DROP NOT NULL;
+  END IF;
+END$$;
+
+-- Ensure exercise_name column exists in workoutlogs
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='workoutlogs' AND column_name='exercise_name'
+  ) THEN
+    ALTER TABLE workoutlogs ADD COLUMN exercise_name VARCHAR(100);
   END IF;
 END$$;

--- a/ProjectSourceCode/SRC/resources/js/script.js
+++ b/ProjectSourceCode/SRC/resources/js/script.js
@@ -89,8 +89,9 @@ document.addEventListener('DOMContentLoaded', function () {
           const items = data.logs
             .map((log) => {
               const details = [];
-              if (log.workoutduration) details.push(log.workoutduration + ' min');
+              if (log.exercise_name) details.push(log.exercise_name);
               if (log.exercise_categories) details.push(log.exercise_categories);
+              if (log.workoutduration) details.push(log.workoutduration + ' min');
               if (log.sets) details.push(log.sets + ' sets');
               if (log.reps) details.push(log.reps + ' reps');
               if (log.weight) details.push(log.weight + ' lbs');


### PR DESCRIPTION
## Summary
- store `exercise_name` in `workoutlogs`
- insert and fetch new field in API routes
- display movement name and type on the weekly view
- include exercise name in modal details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68840a9fb17c832facc2e1c5e7b468f8