### PR TITLE
Fix calendar display without Docker

### DIFF
--- a/ProjectSourceCode/SRC/Views/Pages/workouts.hbs
+++ b/ProjectSourceCode/SRC/Views/Pages/workouts.hbs
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Workout log page</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-    <link rel="stylesheet" href="./resources/css/style.css">
+    <link rel="stylesheet" href="/resources/css/style.css">
   </head>
   <body>
     <div class="row">
@@ -99,6 +99,6 @@
 
     <!-- Bootstrap & Script -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
-    <script src="resources/js/script.js"></script>
+    <script src="/resources/js/script.js"></script>
   </body>
 </html>

--- a/ProjectSourceCode/SRC/index.js
+++ b/ProjectSourceCode/SRC/index.js
@@ -18,7 +18,7 @@ const PORT = 3000;
 
 // ------------------ Database Setup ------------------
 const db = pgp({
-  host: process.env.POSTGRES_HOST,
+  host: process.env.POSTGRES_HOST || 'localhost',
   port: 5432,
   database: process.env.POSTGRES_DB,
   user: process.env.POSTGRES_USER,
@@ -30,8 +30,7 @@ const initSql = fs.readFileSync(path.join(__dirname, 'init_data/create.sql'), 'u
 db.none(initSql)
   .then(() => console.log('database initialized'))
   .catch((err) => {
-    console.error('Database initialization failed:', err);
-    process.exit(1);
+    console.error('Database initialization failed:', err.message);
   });
 
 // ------------------ Middleware ------------------
@@ -44,10 +43,6 @@ app.use(
   })
 );
 app.use('/resources', express.static(path.join(__dirname, 'resources')));
-
-const staticPath = path.join(__dirname, 'ProjectSource/SRC/resources');
-console.log('Serving static files from', staticPath);
-app.use('/resources', express.static(staticPath));
 
 // ------------------ View Engine ------------------
 const { engine } = require('express-handlebars');


### PR DESCRIPTION
## Summary
- default database host to localhost and don't exit when DB init fails
- clean up static file path configuration
- correct resource paths in `workouts.hbs`

## Testing
- `npm test`