### PR TITLE
Fix logout page layout and hide registration link after login

### DIFF
--- a/ProjectSourceCode/SRC/Views/Pages/logout.hbs
+++ b/ProjectSourceCode/SRC/Views/Pages/logout.hbs
@@ -1,15 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Logout Form</title>
-</head>
-<body>
-  </style>
-</head>
-<body>
-  <h1>Logout Successful</h1>
-  <p>Thank you for visiting! You have been logged out.</p>
-  <a href="/login">Click here to login again</a>
-
-</body>
-</html>
+<div class="d-flex justify-content-center align-items-center" style="min-height: 70vh;">
+  <div class="text-center">
+    <h1>Logout Successful</h1>
+    <p>Thank you for visiting! You have been logged out.</p>
+    <a href="/login">Click here to login again</a>
+  </div>
+</div>

--- a/ProjectSourceCode/SRC/Views/Pages/register.hbs
+++ b/ProjectSourceCode/SRC/Views/Pages/register.hbs
@@ -16,8 +16,9 @@
       </div>
       <button type="submit" class="btn btn-success w-100">Register</button>
     </form>
-    <p class="mt-3 text-center">
-      Already have an account? <a href="/login">Login here</a>
-    </p>
+      <p class="mt-3 text-center">
+        Already have an account? <a href="/login">Login here</a>
+      </p>
+    </div>
   </div>
 

--- a/ProjectSourceCode/SRC/Views/partials/header.hbs
+++ b/ProjectSourceCode/SRC/Views/partials/header.hbs
@@ -16,7 +16,9 @@
       <nav>
         <ul class="nav justify-content-center">
           <li class="nav-item"><a class="nav-link" href="/">Home</a></li>
+          {{#unless user}}
           <li class="nav-item"><a class="nav-link" href="/register">Registration</a></li>
+          {{/unless}}
           <li class="nav-item">
             {{#if cardioStar}}
               <span class="me-1 text-warning">&#11088;</span>


### PR DESCRIPTION
## Summary
- hide registration link in header if a user session exists
- improve logout page layout with centered text
- add missing closing tag to register page and keep layout centered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884410e4dc8832fb4ce1652fe97e39b