### PR TITLE
Fix logout page layout and hide registration link after login

### DIFF
--- a/ProjectSourceCode/SRC/Views/Pages/login.hbs
+++ b/ProjectSourceCode/SRC/Views/Pages/login.hbs
@@ -1,5 +1,8 @@
 <div class="d-flex justify-content-center align-items-center" style="min-height: 100vh;">
   <div class="w-100" style="max-width: 500px;">
+    {{#if registered}}
+      <div class="alert alert-success text-center">Registration successful! Please log in.</div>
+    {{/if}}
     <h2 class="mb-4 text-center">Login</h2>
     <form method="POST" action="/login">
       <div class="mb-3">

--- a/ProjectSourceCode/SRC/Views/Pages/logout.hbs
+++ b/ProjectSourceCode/SRC/Views/Pages/logout.hbs
@@ -1,15 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Logout Form</title>
-</head>
-<body>
-  </style>
-</head>
-<body>
-  <h1>Logout Successful</h1>
-  <p>Thank you for visiting! You have been logged out.</p>
-  <a href="/login">Click here to login again</a>
-
-</body>
-</html>
+<div class="d-flex justify-content-center align-items-center" style="min-height: 70vh;">
+  <div class="text-center">
+    <h1>Logout Successful</h1>
+    <p>Thank you for visiting! You have been logged out.</p>
+    <a href="/login">Click here to login again</a>
+  </div>
+</div>

--- a/ProjectSourceCode/SRC/Views/Pages/register.hbs
+++ b/ProjectSourceCode/SRC/Views/Pages/register.hbs
@@ -16,8 +16,9 @@
       </div>
       <button type="submit" class="btn btn-success w-100">Register</button>
     </form>
-    <p class="mt-3 text-center">
-      Already have an account? <a href="/login">Login here</a>
-    </p>
+      <p class="mt-3 text-center">
+        Already have an account? <a href="/login">Login here</a>
+      </p>
+    </div>
   </div>
 

--- a/ProjectSourceCode/SRC/Views/partials/header.hbs
+++ b/ProjectSourceCode/SRC/Views/partials/header.hbs
@@ -16,7 +16,9 @@
       <nav>
         <ul class="nav justify-content-center">
           <li class="nav-item"><a class="nav-link" href="/">Home</a></li>
+          {{#unless user}}
           <li class="nav-item"><a class="nav-link" href="/register">Registration</a></li>
+          {{/unless}}
           <li class="nav-item">
             {{#if cardioStar}}
               <span class="me-1 text-warning">&#11088;</span>

--- a/ProjectSourceCode/SRC/index.js
+++ b/ProjectSourceCode/SRC/index.js
@@ -113,7 +113,7 @@ app.post('/register', async (req, res) => {
       email,
       hash,
     ]);
-    res.redirect('/login');
+    res.redirect('/login?registered=1');
   } catch (err) {
     console.error('Registration error:', err);
     res.redirect('/register');
@@ -122,12 +122,14 @@ app.post('/register', async (req, res) => {
 
 // Login GET
 app.get('/login', (req, res) => {
-  res.render('Pages/login');
+  const registered = req.query.registered === '1';
+  res.render('Pages/login', { registered });
 });
 
 // Alias for Signup links
 app.get('/signup', (req, res) => {
-  res.render('Pages/login');
+  const registered = req.query.registered === '1';
+  res.render('Pages/login', { registered });
 });
 
 // Login POST


### PR DESCRIPTION
## Summary
- hide registration link in header if a user session exists
- improve logout page layout with centered text
- add missing closing tag to register page and keep layout centered
- redirect to login page with success message after registration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884410e4dc8832fb4ce1652fe97e39b